### PR TITLE
Update SimpleCSharpApp.cmd

### DIFF
--- a/SampleCode/Chapter_03/SimpleCSharpApp/SimpleCSharpApp.cmd
+++ b/SampleCode/Chapter_03/SimpleCSharpApp/SimpleCSharpApp.cmd
@@ -3,7 +3,7 @@
 rem A batch file for SimpleCSharpApp.exe
 rem which captures the app's return value.
 dotnet run
-@if "%ERRORLEVEL%" == "0" goto success
+@if "%ERRORLEVEL%" == 0 goto success
 
 :fail
   echo This application has failed!


### PR DESCRIPTION
The environmental variable %ERRORLEVEL% will only compare correctly to an integer and not a string. This is errata for the book cmd program to work correctly.